### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/on_pr_main.yml
+++ b/.github/workflows/on_pr_main.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build Docker Image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           NEXT_PUBLIC_BE_API_URL: ${{ secrets.BE_API_URL }}
           NEXT_PUBLIC_DEFAULT_PROFILE: ${{ secrets.DEFAULT_PROFILE }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore